### PR TITLE
Add reader view overlay with LaTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
-#md editor
+# Markdown Editor
 
-run dev save befor npm start
+Run `npm start` after saving your changes.
+
+The preview area sanitizes Markdown to avoid executing unsafe HTML or scripts.
+
+Math expressions written between dollar signs, like `$ax^2+bx+c=0$`, are rendered with MathJax.
+
+The editor overlays a rendered preview so you see formatted content as you type.
+

--- a/src/index.css
+++ b/src/index.css
@@ -52,57 +52,60 @@ body, html {
   margin: 0;
   padding: 0;
   line-height: 1.5;
-  font-family: "Open Sans", "PT Sans", Calibri, Tahoma, sans-serif;
-  overflow: hidden
+  font-family: "Lato", "PT Sans", Calibri, Tahoma, sans-serif;
+  overflow: hidden;
 }
 
 /* Flex container for the columns */
 .container {
-  display: flex;
-  flex-wrap: wrap;
-  overflow:hidden
+  display: block;
+  overflow: hidden;
 }
 
 /* Textarea styles */
-.editor-column textarea {
-  transition:all 80ms;
+
+.preview-column {
+  position: relative;
   width: 100%;
-  height: calc(100vh - 20px); /* Adjust height as needed */
+  overflow-y: auto;
+  padding: 10px;
+  height: calc(100vh - 20px);
+}
+
+#editor {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
   resize: none;
-  border: 1px solid #ccc;
+  border: none;
   padding: 10px;
   box-sizing: border-box;
   outline: none;
-  background-color: rgba(0, 0, 0, 0);
-  color: rgba(45,45,45,0.5)
+  background: transparent;
+  color: transparent;
+  caret-color: #333;
+  font-family: "Lato", Arial, sans-serif;
+  animation: caretBlink 1s step-end infinite;
+  z-index: 10;
 }
 
-.editor-column {
-  flex: 1;
-  width: 33.33%; /* Set the editor column to approximately one-third */
-  min-width: 0;
-  padding: 10px;
-  box-sizing: border-box;
-  background-color: #ebebeb;
+#viewer {
+  font-family: "Lato", Arial, sans-serif;
+  color: #222;
+  pointer-events: none;
 }
 
-.preview-column {
-  flex: 2;
-  width: 66.66%; /* Set the preview column to approximately two-thirds */
-  border-left: 1px solid #ccc;
-  overflow-y: auto;
-  padding: 10px;
-  max-height: 90vh;
+@keyframes caretBlink {
+  from, to { opacity: 1; }
+  50% { opacity: 0; }
 }
 
 
-/* For smaller screens, show columns stacked */
+/* For smaller screens */
 @media screen and (max-width: 600px) {
-  .container {
-    flex-direction: column;
-  }
-  .editor-column, .preview-column {
-    border: none;
-    width: 100%;
+  .preview-column {
+    height: auto;
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -6,10 +6,10 @@
   <!-- Google Fonts -->
   <title>Sync (1.0.0) by Alessio Liu</title>
   <link rel="stylesheet" href="index.css">
-  <link rel="preconnect" href="https://fonts.googleapis.com"> 
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap" rel="stylesheet">
-  <script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous" ></script> 
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js" integrity="sha384-kQGW6D2PfYZ7R6pujISiFDUFxIr05oig3NbS1Ry6j8Tz7kRXKuX3sI5Yucs5cjox" crossorigin="anonymous"></script>
 </head>
 <body>
   <div class="container">
@@ -19,10 +19,8 @@
     <input type="file" id="importMarkdownButton" accept=".md" class="import" hidden>
 
 
-    <div class="editor-column">
-      <textarea id="editor" placeholder="Type Markdown here..." style="border: none"></textarea>
-    </div>
     <div class="preview-column">
+      <textarea id="editor" placeholder="Type Markdown here..." style="border: none"></textarea>
       <div id="viewer" style="margin: auto;
       max-width: 38rem;
       padding: 2rem;"></div>
@@ -30,6 +28,7 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js" integrity="sha512-GsLlZN/3F2ErC5ifS5QtgpiJtWd43JWSuIgh7mbzZ8zBps+dvLusV+eNQATqgA/HdeKFVgA5v3S/cIrLF7QnIg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="script.js"></script>

--- a/src/script.js
+++ b/src/script.js
@@ -1,84 +1,46 @@
-document.addEventListener('DOMContentLoaded', function() { 
-    const markedScript = document.createElement('script');
-    markedScript.src = 'https://cdn.jsdelivr.net/npm/marked/marked.min.js';
-    const pdf = document.createElement('script');
-    pdf.src = "./jsPDF.js"
-    document.head.appendChild(markedScript);
-    const editor = document.getElementById('editor');
-    const viewer = document.getElementById('viewer');
-    const saveButton = document.getElementById('saveButton');
+document.addEventListener('DOMContentLoaded', () => {
+  const editor = document.getElementById('editor');
+  const viewer = document.getElementById('viewer');
+  const saveButton = document.getElementById('saveButton');
 
+  const updatePreview = () => {
+    const markdownText = editor.value;
+    const html = marked.parse(markdownText);
+    viewer.innerHTML = DOMPurify.sanitize(html);
+    if (window.MathJax && window.MathJax.typesetPromise) {
+      MathJax.typesetPromise([viewer]);
+    }
+  };
 
+  editor.addEventListener('input', updatePreview);
+  updatePreview();
 
+  saveButton.addEventListener('click', () => {
+    html2pdf().from(viewer).save('preview.pdf');
+  });
 
+  function exportToMarkdown() {
+    const markdownContent = editor.value;
+    const blob = new Blob([markdownContent], { type: 'text/markdown;charset=utf-8' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = 'exported_markdown.md';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }
 
-
-
-
-
-
-
-
-
-
-    // Add event listeners
-    editor.addEventListener('input', () => {
-        const markdownText = editor.value;
-        const html = marked.parse(markdownText);
-        viewer.innerHTML = html;
-    });
-    saveButton.addEventListener('click', () => {
-        const viewerContent = viewer; // Assuming viewer is the HTML element to save
-        // Use html2pdf library to save the content as a PDF
-        html2pdf().from(viewerContent).save('preview.pdf');
-      });
-    markedScript.onload = function() {
-        const editor = document.getElementById('editor');
-        const viewer = document.getElementById('viewer');
-    
-        editor.addEventListener('input', () => {
-        const markdownText = editor.value;
-        const html = marked.parse(markdownText);
-        viewer.innerHTML = html;
-        });
+  function readMarkdownFile(event) {
+    const file = event.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      editor.value = e.target.result;
+      updatePreview();
     };
-    function exportToMarkdown() {
-        const markdownContent = document.getElementById('editor').value;
-        const markdownText = `${markdownContent}`;
-      
-        const blob = new Blob([markdownText], { type: 'text/markdown;charset=utf-8' });
-        const fileName = 'exported_markdown.md';
-      
-        const link = document.createElement('a');
-        link.href = URL.createObjectURL(blob);
-        link.download = fileName;
-      
-        // Append the link to the body and trigger the download
-        document.body.appendChild(link);
-        link.click();
-      
-        // Clean up by removing the link
-        document.body.removeChild(link);
-      }
+    reader.readAsText(file);
+  }
 
-      
-      
-
-      function readMarkdownFile(event) {
-        const file = event.target.files[0];
-        const reader = new FileReader();
-      
-        reader.onload = function(event) {
-          const mdContent = event.target.result;
-          document.getElementById('editor').value = mdContent;
-        };
-      
-        reader.readAsText(file);
-      }
-      
-
-    document.getElementById('exportMarkdownButton').addEventListener('click', exportToMarkdown);
-
-    document.getElementById('importMarkdownButton').addEventListener('change', readMarkdownFile);
-
+  document.getElementById('exportMarkdownButton').addEventListener('click', exportToMarkdown);
+  document.getElementById('importMarkdownButton').addEventListener('change', readMarkdownFile);
 });


### PR DESCRIPTION
## Summary
- allow math support via MathJax
- overlay preview over the hidden textarea for reader view
- use Lato font and smooth caret styles
- document rendering behaviour in README

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68416820529c832eba83306b0fe61c78