### PR TITLE
Improve preview layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,9 +2,7 @@
   display: none;
 }
 button, label{
-  position: absolute;
-  bottom: 2rem;
-  left: 2rem;
+  position: relative;
   align-items: center;
   appearance: none;
   background-color: #FCFCFD;
@@ -33,6 +31,16 @@ button, label{
   will-change: box-shadow,transform;
   font-size: 18px;
  }
+
+.hotbar {
+  position: fixed;
+  top: 50%;
+  left: 1rem;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
  
  .button-name:focus {
   box-shadow: #D6D6E7 0 0 0 1.5px inset, rgba(45, 35, 66, 0.4) 0 2px 4px, rgba(45, 35, 66, 0.3) 0 7px 13px -3px, #D6D6E7 0 -3px 0 inset;
@@ -53,6 +61,8 @@ body, html {
   padding: 0;
   line-height: 1.5;
   font-family: "Lato", "PT Sans", Calibri, Tahoma, sans-serif;
+  font-size: 18px;
+  color: #333;
   overflow: hidden;
 }
 
@@ -87,21 +97,20 @@ body, html {
   color: transparent;
   caret-color: #333;
   font-family: "Lato", Arial, sans-serif;
-  animation: caretBlink 1s step-end infinite;
   z-index: 10;
 }
 
 #viewer {
   font-family: "Lato", Arial, sans-serif;
-  color: #222;
+  color: #333;
   pointer-events: none;
+  margin: 2rem auto;
+  padding: 2rem;
+  max-width: 21cm;
+  min-height: 29.7cm;
+  box-sizing: border-box;
+  background: white;
 }
-
-@keyframes caretBlink {
-  from, to { opacity: 1; }
-  50% { opacity: 0; }
-}
-
 
 /* For smaller screens */
 @media screen and (max-width: 600px) {

--- a/src/index.html
+++ b/src/index.html
@@ -13,17 +13,16 @@
 </head>
 <body>
   <div class="container">
-    <button id="saveButton">Save</button>
-    <button id="exportMarkdownButton" style="left: 8rem">Export Markdown</button>
-    <label for="importMarkdownButton" style="bottom: 6rem">Open</label>
-    <input type="file" id="importMarkdownButton" accept=".md" class="import" hidden>
-
+    <div class="hotbar">
+      <button id="saveButton" class="button-name">Save</button>
+      <button id="exportMarkdownButton" class="button-name">Export</button>
+      <label for="importMarkdownButton" class="button-name">Open</label>
+      <input type="file" id="importMarkdownButton" accept=".md" class="import" hidden>
+    </div>
 
     <div class="preview-column">
       <textarea id="editor" placeholder="Type Markdown here..." style="border: none"></textarea>
-      <div id="viewer" style="margin: auto;
-      max-width: 38rem;
-      padding: 2rem;"></div>
+      <div id="viewer"></div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- stop caret animation causing viewer flicker
- add floating hotbar for save/export/open controls
- make fonts larger and darker
- give viewer A4-like margins

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68416f1d5c14832e93c2f2257436b6e9